### PR TITLE
Fix tests

### DIFF
--- a/src/nodetool/dsl/lib/librosa/analysis.py
+++ b/src/nodetool/dsl/lib/librosa/analysis.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/librosa/segmentation.py
+++ b/src/nodetool/dsl/lib/librosa/segmentation.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/pedalboard.py
+++ b/src/nodetool/dsl/lib/pedalboard.py
@@ -1,7 +1,4 @@
-from pydantic import BaseModel, Field
-import typing
-from typing import Any
-import nodetool.metadata.types
+from pydantic import Field
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
 

--- a/src/nodetool/dsl/lib/synthesis.py
+++ b/src/nodetool/dsl/lib/synthesis.py
@@ -1,6 +1,5 @@
-from pydantic import BaseModel, Field
+from pydantic import Field
 import typing
-from typing import Any
 import nodetool.metadata.types
 import nodetool.metadata.types as types
 from nodetool.dsl.graph import GraphNode
@@ -72,10 +71,6 @@ class FM_Synthesis(GraphNode):
     @classmethod
     def get_node_type(cls):
         return "lib.synthesis.FM_Synthesis"
-
-
-import nodetool.nodes.lib.synthesis
-import nodetool.nodes.lib.synthesis
 
 
 class Oscillator(GraphNode):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+import pytest
+from io import BytesIO
+from pydub import AudioSegment
+from nodetool.workflows.processing_context import ProcessingContext
+
+
+@pytest.fixture(autouse=True)
+def patch_audio_loader(monkeypatch):
+    async def audio_to_audio_segment(self, audio_ref):
+        audio_bytes = await self.asset_to_io(audio_ref)
+        if hasattr(audio_bytes, "seek"):
+            audio_bytes.seek(0)
+        return AudioSegment.from_file(audio_bytes, format="wav")
+
+    monkeypatch.setattr(
+        ProcessingContext,
+        "audio_to_audio_segment",
+        audio_to_audio_segment,
+        raising=False,
+    )
+
+    async def audio_from_segment(
+        self, audio_segment, name=None, parent_id=None, **kwargs
+    ):
+        buffer = BytesIO()
+        audio_segment.export(buffer, format="wav")
+        buffer.seek(0)
+        return await self.audio_from_io(buffer, name=name, parent_id=parent_id)
+
+    monkeypatch.setattr(
+        ProcessingContext,
+        "audio_from_segment",
+        audio_from_segment,
+        raising=False,
+    )
+    yield

--- a/tests/nodes/lib/test_audio_analysis.py
+++ b/tests/nodes/lib/test_audio_analysis.py
@@ -1,4 +1,4 @@
-from io import BytesIO
+import tempfile
 import pytest
 import numpy as np
 from pydub import AudioSegment
@@ -21,9 +21,10 @@ from nodetool.nodes.lib.librosa.analysis import (
 
 
 dummy_tensor = NPArray.from_numpy(np.random.rand(100, 100))
-buffer = BytesIO()
-AudioSegment.silent(5000, 44_100).export(buffer, format="mp3")
-dummy_audio = AudioRef(data=buffer.getvalue())
+tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+AudioSegment.silent(5000, 44_100).export(tmp.name, format="wav")
+tmp.close()
+dummy_audio = AudioRef(uri=tmp.name)
 
 
 @pytest.fixture

--- a/tests/nodes/lib/test_audio_effects.py
+++ b/tests/nodes/lib/test_audio_effects.py
@@ -1,5 +1,5 @@
 import pytest
-from io import BytesIO
+import tempfile
 from pydub import AudioSegment
 from nodetool.workflows.base_node import BaseNode
 from nodetool.workflows.processing_context import ProcessingContext
@@ -24,9 +24,10 @@ from nodetool.nodes.lib.pedalboard import (
 )
 
 # Create a dummy AudioRef for testing
-buffer = BytesIO()
-AudioSegment.silent(duration=5000, frame_rate=44100).export(buffer, format="mp3")
-dummy_audio = AudioRef(data=buffer.getvalue())
+tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+AudioSegment.silent(duration=5000, frame_rate=44100).export(tmp.name, format="wav")
+tmp.close()
+dummy_audio = AudioRef(uri=tmp.name)
 
 
 @pytest.fixture

--- a/tests/nodes/lib/test_audio_segmentation.py
+++ b/tests/nodes/lib/test_audio_segmentation.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-from io import BytesIO
+import tempfile
 from pydub import AudioSegment
 from nodetool.workflows.processing_context import ProcessingContext
 from nodetool.metadata.types import AudioRef, NPArray
@@ -10,9 +10,10 @@ from nodetool.nodes.lib.librosa.segmentation import (
 )
 
 # Create a dummy AudioRef for testing
-buffer = BytesIO()
-AudioSegment.silent(duration=5000, frame_rate=44100).export(buffer, format="wav")
-dummy_audio = AudioRef(data=buffer.getvalue())
+tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
+AudioSegment.silent(duration=5000, frame_rate=44100).export(tmp.name, format="wav")
+tmp.close()
+dummy_audio = AudioRef(uri=tmp.name)
 
 # Create a dummy Tensor for onsets
 dummy_onsets = NPArray.from_numpy(np.array([0.5, 1.0, 1.5, 2.0]))

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,8 +1,14 @@
 import json
 from pathlib import Path
 
-PACKAGE_METADATA_PATH = Path(__file__).resolve().parents[1] / 'src' / 'nodetool' / 'package_metadata' / 'nodetool-lib-audio.json'
-PYPROJECT_PATH = Path(__file__).resolve().parents[1] / 'pyproject.toml'
+PACKAGE_METADATA_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "nodetool"
+    / "package_metadata"
+    / "nodetool-lib-audio.json"
+)
+PYPROJECT_PATH = Path(__file__).resolve().parents[1] / "pyproject.toml"
 
 
 def load_metadata():
@@ -11,21 +17,23 @@ def load_metadata():
 
 def test_metadata_has_correct_name_and_version():
     metadata = load_metadata()
-    assert metadata['name'] == 'nodetool-lib-audio'
+    assert metadata["name"] == "nodetool-lib-audio"
     # ensure version matches pyproject
     pyproject_text = PYPROJECT_PATH.read_text()
     for line in pyproject_text.splitlines():
-        if line.startswith('version'):
-            version = line.split('=')[-1].strip().strip('"')
+        if line.startswith("version"):
+            version = line.split("=")[-1].strip().strip('"')
             break
     else:
-        raise AssertionError('Version not found in pyproject.toml')
-    assert metadata['version'] == version
+        raise AssertionError("Version not found in pyproject.toml")
+    assert metadata["version"] == version
 
 
 def test_waveform_property_contains_expected_enums():
     metadata = load_metadata()
-    nodes = metadata['nodes']
-    oscillator_node = next(n for n in nodes if n.get('title') == 'Oscillator')
-    waveform_prop = next(p for p in oscillator_node['properties'] if p['name'] == 'waveform')
-    assert waveform_prop['type']['values'] == ['sine', 'square', 'sawtooth', 'triangle']
+    nodes = metadata["nodes"]
+    oscillator_node = next(n for n in nodes if n.get("title") == "Oscillator")
+    waveform_prop = next(
+        p for p in oscillator_node["properties"] if p["name"] == "waveform"
+    )
+    assert waveform_prop["type"]["values"] == ["sine", "square", "sawtooth", "triangle"]


### PR DESCRIPTION
## Summary
- use temporary WAV files for testing
- patch ProcessingContext to avoid ffmpeg
- update generated DSL modules for linting
- format tests

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`